### PR TITLE
fix: download java-db to cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN apt update && apt install -y wget curl && bash download_trivydbv2.sh
 FROM alpine:3.15.0
 WORKDIR /trivydb/
 COPY --from=builder /source/trivy.db .
+COPY --from=builder /source/java-db/trivy-java.db ./java-db/
+COPY --from=builder /source/java-db/metadata.json ./java-db/
 COPY --from=builder /source/metadata.json .
 CMD ["sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apt update && apt install -y wget curl && bash download_trivydbv2.sh
 
 FROM alpine:3.15.0
 WORKDIR /trivydb/
-COPY --from=builder /source/trivy.db .
-COPY --from=builder /source/java-db/trivy-java.db ./java-db/
-COPY --from=builder /source/java-db/metadata.json ./java-db/
-COPY --from=builder /source/metadata.json .
+COPY --from=builder /source/db  ./db
+COPY --from=builder /source/java-db  ./java-db
 CMD ["sh"]

--- a/download_trivydbv2.sh
+++ b/download_trivydbv2.sh
@@ -3,9 +3,9 @@ mkdir -p oras-install
 tar -zxf oras_0.12.0_*.tar.gz -C oras-install/
 mv oras-install/oras .
 rm -rf oras_0.12.0_*.tar.gz oras-install/
-
+mkdir -p db
 ./oras pull ghcr.io/aquasecurity/trivy-db:2 -a \
-    && tar -xzvf db.tar.gz \
+    && tar -xzvf db.tar.gz  -C ./db \
     && rm db.tar.gz
 
 mkdir -p java-db

--- a/download_trivydbv2.sh
+++ b/download_trivydbv2.sh
@@ -7,3 +7,9 @@ rm -rf oras_0.12.0_*.tar.gz oras-install/
 ./oras pull ghcr.io/aquasecurity/trivy-db:2 -a \
     && tar -xzvf db.tar.gz \
     && rm db.tar.gz
+
+mkdir -p java-db
+./oras pull ghcr.io/aquasecurity/trivy-java-db:1 -a \
+    && tar -xzvf javadb.tar.gz -C ./java-db \
+    && rm javadb.tar.gz
+ 


### PR DESCRIPTION
the java database will be downloaded on each scan unless it is cached. It is updated once a week so it makes sense to use a similar approach. The copy-vulns-db script should look something like this.  
``` 
        -   
          name: copy-vulns-db
          resources: {}
          script: |
            #!/bin/sh
            mkdir -p ~/.cache/trivy/java-db
            mv /trivydb/java-db/* ~/.cache/trivy/java-db/

            mkdir -p ~/.cache/trivy/db
            mv /trivydb/* ~/.cache/trivy/db/
```

since the java-db is placed in a sub folder it must be moved first